### PR TITLE
Fix ppc64el issue #3157

### DIFF
--- a/src/emu/xtal.h
+++ b/src/emu/xtal.h
@@ -81,8 +81,8 @@ constexpr XTAL operator *(unsigned int mult, const XTAL &xtal) { return XTAL(xta
 constexpr XTAL operator *(double       mult, const XTAL &xtal) { return XTAL(xtal.base(), mult * xtal.dvalue()); }
 
 constexpr XTAL operator ""_Hz_XTAL(long double clock) { return XTAL(double(clock)); }
-constexpr XTAL operator ""_kHz_XTAL(long double clock) { return XTAL(double(clock * 1e3)); }
-constexpr XTAL operator ""_MHz_XTAL(long double clock) { return XTAL(double(clock * 1e6)); }
+constexpr XTAL operator ""_kHz_XTAL(long double clock) { return XTAL(double(clock) * 1e3); }
+constexpr XTAL operator ""_MHz_XTAL(long double clock) { return XTAL(double(clock) * 1e6); }
 
 constexpr XTAL operator ""_Hz_XTAL(unsigned long long clock) { return XTAL(double(clock)); }
 constexpr XTAL operator ""_kHz_XTAL(unsigned long long clock) { return XTAL(double(clock) * 1e3); }


### PR DESCRIPTION
This is probably due to the fact that IBM 128bit long double format is not constant folded.
I slighlty rewrote ""_kHz_XTAL(long double clock) and ""_MHz_XTAL(long double clock)
the way ""_kHz_XTAL(unsigned long long clock) and ""_MHz_XTAL(unsigned long long clock) are written few lines after which makes the compiler happy.
I initially proposed this patch on Debian, which fixes the build : 
https://salsa.debian.org/games-team/mame/merge_requests/15/diffs
Thanks,

F.